### PR TITLE
fix(dart_frog): add default handler for disallowed http methods

### DIFF
--- a/packages/dart_frog/lib/src/request.dart
+++ b/packages/dart_frog/lib/src/request.dart
@@ -1,5 +1,22 @@
 part of '_internal.dart';
 
+/// {@template unsupported_http_method_exception}
+/// Exception thrown when an unsupported HTTP method is used.
+/// {@endtemplate}
+class UnsupportedHttpMethodException implements Exception {
+  /// {@macro unsupported_http_method_exception}
+  const UnsupportedHttpMethodException(this.method);
+
+  /// The unsupported http method.
+  final String method;
+
+  @override
+  String toString() => '''
+Unsupported HTTP method: $method. 
+The following methods are supported:
+${HttpMethod.values.map((m) => m.value.toUpperCase()).join(', ')}.''';
+}
+
 /// {@template request}
 /// An HTTP request.
 /// {@endtemplate}
@@ -112,7 +129,10 @@ class Request {
 
   /// The [HttpMethod] associated with the request.
   HttpMethod get method {
-    return HttpMethod.values.firstWhere((m) => m.value == _request.method);
+    return HttpMethod.values.firstWhere(
+      (m) => m.value == _request.method,
+      orElse: () => throw UnsupportedHttpMethodException(_request.method),
+    );
   }
 
   /// Returns a [Stream] representing the body.

--- a/packages/dart_frog/test/src/request_test.dart
+++ b/packages/dart_frog/test/src/request_test.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:dart_frog/dart_frog.dart';
+import 'package:dart_frog/src/_internal.dart';
 import 'package:dart_frog/src/body_parsers/body_parsers.dart';
 import 'package:test/test.dart';
 
@@ -41,6 +42,20 @@ void main() {
       const body = 'hello';
       final request = Request('GET', localhost, body: utf8.encode(body));
       expect(request.bytes(), emits(utf8.encode(body)));
+    });
+
+    test('throw exception when method is unsupported', () {
+      final request = Request('FOO', localhost);
+      expect(
+        () => request.method,
+        throwsA(
+          isA<UnsupportedHttpMethodException>()
+              .having((e) => e.toString(), 'toString', '''
+Unsupported HTTP method: FOO. 
+The following methods are supported:
+${HttpMethod.values.map((m) => m.value.toUpperCase()).join(', ')}.'''),
+        ),
+      );
     });
 
     test('throws exception when unable to read body', () async {

--- a/packages/dart_frog/test/src/router_test.dart
+++ b/packages/dart_frog/test/src/router_test.dart
@@ -91,6 +91,13 @@ void main() {
     expect(response.statusCode, equals(HttpStatus.notFound));
     expect(response.body, equals('Route not found'));
 
+    final streamedResponse = await http.Client().send(
+      http.Request('FOO', Uri.parse('${server.url}/hello/world')),
+    );
+    response = await http.Response.fromStream(streamedResponse);
+    expect(response.statusCode, equals(HttpStatus.methodNotAllowed));
+    expect(response.body, equals('Method not allowed'));
+
     response = await http.get(Uri.parse('${server.url}/hello/world'));
     expect(response.statusCode, equals(HttpStatus.ok));
     expect(response.body, equals('hello'));
@@ -443,6 +450,26 @@ void main() {
     final response = Router.routeNotFound.copyWith(headers: {'foo': 'bar'});
     expect(response.headers['foo'], equals('bar'));
     expect(response.body(), completion(equals('Route not found')));
+  });
+
+  test('can call Router.methodNotAllowed.body() multiple times', () async {
+    final b1 = await Router.methodNotAllowed.body();
+    expect(b1, 'Method not allowed');
+    final b2 = await Router.methodNotAllowed.body();
+    expect(b2, b1);
+  });
+
+  test('can call Router.methodNotAllowed.bytes() multiple times', () async {
+    final b1 = Router.methodNotAllowed.bytes();
+    expect(b1, emits(utf8.encode('Method not allowed')));
+    final b2 = Router.methodNotAllowed.bytes();
+    expect(b2, emits(utf8.encode('Method not allowed')));
+  });
+
+  test('can call Router.methodNotAllowed.copyWith()', () async {
+    final response = Router.methodNotAllowed.copyWith(headers: {'foo': 'bar'});
+    expect(response.headers['foo'], equals('bar'));
+    expect(response.body(), completion(equals('Method not allowed')));
   });
 
   test('can mount route without params', () async {

--- a/packages/dart_frog_cli/e2e/test/dev_test.dart
+++ b/packages/dart_frog_cli/e2e/test/dev_test.dart
@@ -84,7 +84,7 @@ void main() {
           });
 
           fail('exception not thrown');
-        } catch (e) {
+        } on Exception catch (e) {
           expect(e.toString(), contains('Could not start the VM service:'));
 
           expect(
@@ -131,6 +131,6 @@ extension<T> on Future<T> {
   Future<void> ignoreErrors() async {
     try {
       await this;
-    } catch (_) {}
+    } on Exception catch (_) {}
   }
 }

--- a/packages/dart_frog_cli/e2e/test/dev_test.dart
+++ b/packages/dart_frog_cli/e2e/test/dev_test.dart
@@ -84,7 +84,7 @@ void main() {
           });
 
           fail('exception not thrown');
-        } on Exception catch (e) {
+        } catch (e) {
           expect(e.toString(), contains('Could not start the VM service:'));
 
           expect(
@@ -131,6 +131,6 @@ extension<T> on Future<T> {
   Future<void> ignoreErrors() async {
     try {
       await this;
-    } on Exception catch (_) {}
+    } catch (_) {}
   }
 }


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY**

## Description

<!--- Describe your changes in detail -->
- fix(dart_frog): add default handler for disallowed http methods
  - This fixes a bug where previously request made to a dart frog server with arbitrary http methods would result in a 500 (internal server error). With the changes in the PR, that case would result in a 405 (method not allowed)

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [X] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
